### PR TITLE
Add Binder, simplify hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # ipython-markdown-inspector
 
-[![tests](https://github.com/krassowski/ipython-markdown-inspector/workflows/tests/badge.svg)](https://github.com/krassowski/ipython-markdown-inspector/actions?query=workflow%3A%22tests%22)
+[![tests](https://github.com/krassowski/ipython-markdown-inspector/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/krassowski/ipython-markdown-inspector/actions/workflows/tests.yml)
 ![CodeQL](https://github.com/krassowski/ipython-markdown-inspector/workflows/CodeQL/badge.svg)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/krassowski/ipython-markdown-inspector/main?urlpath=lab)
 [![pypi-version](https://img.shields.io/pypi/v/ipython-markdown-inspector.svg)](https://python.org/pypi/ipython-markdown-inspector)
 
 IPython extension providing inspection results as Markdown, enabling better integration with Jupyter Notebook and JupyterLab.

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,17 @@
+name: ipython-markdown-inspector
+
+channels:
+  - conda-forge
+  - nodefaults
+
+dependencies:
+  - python =3.11
+  - pip
+  - jupyterlab >=4.1
+  - hatchling >=1.5.0
+  - ipykernel >=6.29
+  - notebook >=7.1
+  - wheel
+  - build
+  - pip:
+    - ipython >=8.22

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - wheel
   - build
   - ipython >=8.22
+  - traitlets >=5.14.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,5 +13,4 @@ dependencies:
   #- notebook >=7.1
   - wheel
   - build
-  - pip:
-    - ipython >=8.22
+  - ipython >=8.22

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,12 +5,12 @@ channels:
   - nodefaults
 
 dependencies:
-  - python =3.10
+  #- python =3.10
   - pip
-  - jupyterlab >=4.1
+  #- jupyterlab >=4.1
   - hatchling >=1.5.0
-  - ipykernel >=6.29
-  - notebook >=7.1
+  #- ipykernel >=6.29
+  #- notebook >=7.1
   - wheel
   - build
   - pip:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nodefaults
 
 dependencies:
-  - python =3.11
+  - python =3.10
   - pip
   - jupyterlab >=4.1
   - hatchling >=1.5.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,12 +5,13 @@ channels:
   - nodefaults
 
 dependencies:
-  #- python =3.10
+  - python =3.10
   - pip
-  #- jupyterlab >=4.1
+  - jupyterlab >=4.1
   - hatchling >=1.5.0
-  #- ipykernel >=6.29
-  #- notebook >=7.1
+  - ipykernel >=6.29
+  - notebook >=7.1
+  - jupyter_server >=2.12
   - wheel
   - build
   - ipython >=8.22

--- a/binder/ipython_config.py
+++ b/binder/ipython_config.py
@@ -1,1 +1,1 @@
-# c.InteractiveShellApp.extensions = ["ipython_markdown_inspector"]  # noqa: F821
+c.InteractiveShellApp.extensions = ["ipython_markdown_inspector"]  # noqa: F821

--- a/binder/ipython_config.py
+++ b/binder/ipython_config.py
@@ -1,1 +1,1 @@
-c.InteractiveShellApp.extensions = ["ipython_markdown_inspector"]  # noqa: F821
+# c.InteractiveShellApp.extensions = ["ipython_markdown_inspector"]  # noqa: F821

--- a/binder/ipython_config.py
+++ b/binder/ipython_config.py
@@ -1,0 +1,1 @@
+c.InteractiveShellApp.extensions = ["ipython_markdown_inspector"]  # noqa: F821

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+source activate ${NB_PYTHON_PREFIX}
+
+pip install -v -e . --no-build-isolation
+
+mkdir -p ~/.ipython/profile_default/
+cp binder/ipython_config.py ~/.ipython/profile_default/

--- a/ipython_markdown_inspector/__init__.py
+++ b/ipython_markdown_inspector/__init__.py
@@ -1,18 +1,8 @@
-from functools import partial
 from typing import List
 
 from IPython.core.interactiveshell import InteractiveShell
-from IPython.core.oinspect import InspectorHookData
 
 from .formatter import as_markdown
-
-
-def hook(
-    data: InspectorHookData,
-    *_,
-    ipython: InteractiveShell,
-) -> str:
-    return as_markdown(data)
 
 
 ORIGINAL_HOOK = None
@@ -21,7 +11,7 @@ ORIGINAL_HOOK = None
 def load_ipython_extension(ipython: InteractiveShell):
     global ORIGINAL_HOOK
     ORIGINAL_HOOK = ipython.inspector.mime_hooks.get("text/markdown", None)
-    ipython.inspector.mime_hooks["text/markdown"] = partial(hook, ipython=ipython)
+    ipython.inspector.mime_hooks["text/markdown"] = as_markdown
 
 
 def unload_ipython_extension(ipython: InteractiveShell):


### PR DESCRIPTION
Adds Binder for preview, simplifies hook to match IPython 8.22

Note: traitlets pin is required because of a IPython 8.22 bug.